### PR TITLE
Add dependabot automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: maven
+    directory: scaffolder-templates/parasol-java-template/skeleton
+    schedule:
+      interval: daily
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,29 @@
+
+name: Dependabot auto-merge
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Enable auto-merge for Dependabot PRs
+        if: (steps.metadata.outputs.update-type == 'version-update:semver-patch') || (steps.metadata.outputs.update-type == 'version-update:semver-minor') || (steps.metadata.outputs.update-type == 'version-update:semver-major')
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/simple-app-build-test.yml
+++ b/.github/workflows/simple-app-build-test.yml
@@ -1,0 +1,70 @@
+name: Simple app build and test
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**/*.md'
+      - '.github/dependabot.yml'
+      - '.github/workflows/dependabot-automerge.yml'
+      - 'showcase-templates.yaml'
+      - 'scaffolder-templates/parasol-java-template/manifests/**'
+      - 'scaffolder-templates/parasol-java-template/prompt-testing/**'
+      - 'scaffolder-templates/parasol-java-template/docs/**'
+      - 'scaffolder-templates/parasol-java-template/template.yaml'
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - '**/*.md'
+      - '.github/dependabot.yml'
+      - '.github/workflows/dependabot-automerge.yml'
+      - 'showcase-templates.yaml'
+      - 'scaffolder-templates/parasol-java-template/manifests/**'
+      - 'scaffolder-templates/parasol-java-template/prompt-testing/**'
+      - 'scaffolder-templates/parasol-java-template/docs/**'
+      - 'scaffolder-templates/parasol-java-template/template.yaml'
+  workflow_dispatch:
+
+concurrency:
+  group: "workflow = ${{ github.workflow }}, ref = ${{ github.event.ref }}, pr = ${{ github.event.pull_request.id }}"
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+defaults:
+  run:
+    shell: bash
+    working-directory: scaffolder-templates/parasol-java-template
+
+jobs:
+  jvm-build-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java:
+          - '21'
+    services:
+      ollama:
+        image: ollama/ollama
+        ports:
+          - 11434:11434
+    name: "jvm-build-test-${{ matrix.java }}"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Java ${{ matrix.java }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: temurin
+          cache: maven
+
+      - name: "build-test-jvm-java${{ matrix.java }}"
+        run: |
+          ./mvnw -B clean verify \
+            -Dquarkus.profile=ollama \
+            -Dquarkus.test.profile=ollama,test \
+            -Dquarkus.test.integration-test-profile=ollama,prod \
+            -Dquarkus.http.host=0.0.0.0 \
+            -Dmaven.compiler.release=${{ matrix.java }}

--- a/.github/workflows/simple-app-build-test.yml
+++ b/.github/workflows/simple-app-build-test.yml
@@ -34,7 +34,7 @@ concurrency:
 defaults:
   run:
     shell: bash
-    working-directory: scaffolder-templates/parasol-java-template
+    working-directory: scaffolder-templates/parasol-java-template/skeleton
 
 jobs:
   jvm-build-test:


### PR DESCRIPTION
Adds automation so dependabot will automatically keep dependencies up to date.

This needs to co-incide with some branch protection rules that need to be enabled on the repo. Don't merge this until that is done.