### PR TITLE
Revert "Bump io.quarkiverse.langchain4j:quarkus-langchain4j-bom from 0.21.0 to 0.22.0 in /scaffolder-templates/parasol-java-template/skeleton"

### DIFF
--- a/scaffolder-templates/parasol-java-template/skeleton/pom.xml
+++ b/scaffolder-templates/parasol-java-template/skeleton/pom.xml
@@ -11,7 +11,7 @@
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus.langchain4j.version>0.22.0</quarkus.langchain4j.version>
+    <quarkus.langchain4j.version>0.21.0</quarkus.langchain4j.version>
     <quarkus.playwright.version>2.0.0</quarkus.playwright.version>
     <quarkus.quinoa.version>2.5.1</quarkus.quinoa.version>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>


### PR DESCRIPTION
Reverts rh-rad-ai-roadshow/ai-llm-template#65